### PR TITLE
#315 Fix afterIsEmailAvailable plugin problems

### DIFF
--- a/Plugin/AccountManagement.php
+++ b/Plugin/AccountManagement.php
@@ -77,16 +77,15 @@ class AccountManagement
             return $result;
         }
 
-        /** @var Quote $quote */
-        $quote = $this->cartRepository->get($cartId);
-        $quote->setCustomerEmail($customerEmail);
-
         try {
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->get($cartId);
+            $quote->setCustomerEmail($customerEmail);
+            
             $this->cartRepository->save($quote);
-
-            return $result;
         } catch (Exception $e) {
-            return false;
         }
+        
+        return $result;
     }
 }


### PR DESCRIPTION
A combination of 
- https://github.com/mageplaza/magento-2-smtp/pull/234 - just get the quote, ignore its "active" status
- https://github.com/mageplaza/magento-2-smtp/pull/239 - catch all the errors
- https://github.com/mageplaza/magento-2-smtp/pull/361 - preserve return value

fixes an issue https://github.com/mageplaza/magento-2-smtp/issues/315
